### PR TITLE
Fix celebrity data fetch and parsing

### DIFF
--- a/app/src/main/java/com/example/thecelebritygussinggame/MainActivity.java
+++ b/app/src/main/java/com/example/thecelebritygussinggame/MainActivity.java
@@ -4,7 +4,6 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
@@ -99,7 +98,7 @@ public class MainActivity extends AppCompatActivity {
         @Override
         protected String doInBackground(String... urls) {
 
-            String result = "";
+            StringBuilder result = new StringBuilder();
 
             URL url;
 
@@ -110,6 +109,8 @@ public class MainActivity extends AppCompatActivity {
                 url = new URL(urls[0]);
 
                 urlConnection = (HttpsURLConnection) url.openConnection();
+                urlConnection.setRequestProperty("User-Agent", "Mozilla/5.0 (Android) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0 Mobile Safari/537.36");
+                urlConnection.setRequestProperty("Accept-Language", "en-US,en;q=0.9");
 
                 InputStream in  = urlConnection.getInputStream();
 
@@ -121,13 +122,13 @@ public class MainActivity extends AppCompatActivity {
 
                     char current = (char) data;
 
-                    result += current;
+                    result.append(current);
 
                     data = reader.read();
 
                 }
 
-                return result;
+                return result.toString();
 
             } catch (Exception e) {
 
@@ -221,41 +222,27 @@ public class MainActivity extends AppCompatActivity {
 
             result = task.execute("https://www.imdb.com/list/ls052283250/").get();
 
-            String[] splitResult = result.split("<div class=\"desc\"");
+            Pattern p = Pattern.compile("<img[^>]*alt=\\\"(.*?)\\\"[^>]*(?:loadlate|data-src|src)=\\\"(https://m\\.media-amazon\\.com/images/[^\\\"]+?\\.jpg)[^\\\"]*\\\"", Pattern.DOTALL);
 
-            Pattern p = Pattern.compile("src=\"(.*?).jpg\"");
-
-            Matcher m = p.matcher(splitResult[0]);
-
-            while (m.find()) {
-
-                celebURLs.add(m.group(1));
-
-                counter++;
-
-                //System.out.println(m.group(1));
-
-            }
-
-            System.out.println(counter);
-
-            counter = 0;
-
-            p = Pattern.compile("img alt=\"(.*?)\"");
-
-            m = p.matcher(splitResult[0]);
+            Matcher m = p.matcher(result);
 
             while (m.find()) {
 
                 celebNames.add(m.group(1));
 
-                counter++;
+                celebURLs.add(m.group(2));
 
-                //System.out.println(m.group(1));
+                counter++;
 
             }
 
-            System.out.println(counter);
+            if (celebURLs.isEmpty()) {
+
+                Toast.makeText(getApplicationContext(), "Unable to load celebrity data. Please try again later.", LENGTH_SHORT).show();
+
+                return;
+
+            }
 
             newQuestion();
 


### PR DESCRIPTION
### Motivation
- Ensure the app reliably downloads celebrity images and names from IMDb by using realistic request headers and robust parsing.
- Avoid poor performance from repeated string concatenation when reading remote HTML.
- Handle the case where parsing fails by informing the user instead of crashing or showing an empty UI.
- Remove an unused import to keep the code clean.

### Description
- Replace incremental string concatenation with a `StringBuilder` and return `result.toString()` from `DownloadTask.doInBackground`.
- Add IMDb-friendly request headers (`User-Agent` and `Accept-Language`) on the `HttpsURLConnection` to avoid blocked/tunneled requests.
- Update the HTML parsing to use a single regex that captures the `alt` text and the JPEG image URL (`m.media-amazon.com`), and populate `celebNames` and `celebURLs` accordingly.
- Show a friendly `Toast` and return early if no celebrity data is parsed, and remove the unused `android.util.Log` import.

### Testing
- No automated tests were run against this change.
- (Manual runtime/network checks were performed during development but are not included as automated tests.)
